### PR TITLE
feat: add Owner tag to ECR repository resource

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,6 +45,7 @@ resource "aws_ecr_repository" "app_repo" {
     Name        = var.app_name
     Environment = "poc"
     ManagedBy   = "terraform"
+    Owner       = "Infrastructure"
   }
 }
 


### PR DESCRIPTION
  Add Infrastructure team ownership tag to aws_ecr_repository for better resource management and accountability.